### PR TITLE
Specify Farmer's Delight dependency correctly

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -62,3 +62,10 @@ description="A Farmer's Delight addon containing various additions."
     versionRange="[1.19.2,1.20)"
     ordering="NONE"
     side="BOTH"
+[[dependencies.cookscollection]]
+    modId="farmersdelight"
+    mandatory=true
+# This version range declares a minimum of the current minecraft version up to but not including the next major version
+    versionRange="[1.19.2-1.2.4,)"
+    ordering="AFTER"
+    side="BOTH"


### PR DESCRIPTION
Farmer's Delight is missing from the `mods.toml`, leading to harder to explain crashes without it present. I've also made it specify it needs to load after Farmer's Delight, as without that set it can crash in larger modpacks like Raspberry Flavoured.