### PR TITLE
implement sided inventory for the oven

### DIFF
--- a/src/main/java/com/baisylia/cookscollection/block/entity/custom/OvenBlockEntity.java
+++ b/src/main/java/com/baisylia/cookscollection/block/entity/custom/OvenBlockEntity.java
@@ -428,7 +428,7 @@ public class OvenBlockEntity extends BlockEntity implements MenuProvider, Worldl
 
     @Override
     public void clearContent() {
-        for(int i = 0; i < 11; ++i) {
+        for(int i = 0; i < 10; ++i) {
             this.itemHandler.setStackInSlot(i, ItemStack.EMPTY);
         }
     }


### PR DESCRIPTION
this adds sided inventory interactions for the oven. items inserted from any direction will go into the 3x3 ingredient grid, while hoppers extracting from below will only extract the crafted item from the result slot